### PR TITLE
Allow skin customization

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3,5 +3,6 @@
 		"authors": [ "Park Min Hyeok" ]
 	},
 	"skinname-foobar": "Neptune",
+	"neptune-title": "프흠위키: 프리 흠터레스팅 위키",
 	"foobar-skin-desc": "🚀 Neptune mediawiki skin"
 }

--- a/skin.json
+++ b/skin.json
@@ -10,6 +10,11 @@
 	"requires": {
 		"MediaWiki": ">= 1.35.0"
 	},
+	"MessagesDirs": {
+		"Neptune": [
+			"i18n"
+		]
+	},
 	"ValidSkinNames": {
 		"neptune": "Neptune"
 	},

--- a/src/Neptune.template.php
+++ b/src/Neptune.template.php
@@ -21,7 +21,7 @@ class NeptuneTemplate extends BaseTemplate {
                     <?php $this->html( 'title' ); ?>
                   </div>
                   <div class="text-xs text-neutral-500">
-                    프흠위키: 프리 흠터레스팅 위키
+                    <?php $this->msg( 'neptune-title' ) ?>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Rather than hard coding Korean text in the skin, you can use messages to allow customization via an edit to  MediaWiki:Neptune-title :-)